### PR TITLE
Added jax as a hatch test extra-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,12 @@ classifiers = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/jsmfsb"]
 
+[tool.hatch.envs.hatch-test]
+extra-dependencies = [
+  'jax',
+]
+
 [project.urls]
 Homepage = "https://github.com/darrenjw/jax-smfsb"
 Documentation = "https://jax-smfsb.readthedocs.io/"
 Issues = "https://github.com/darrenjw/jax-smfsb/issues"
-


### PR DESCRIPTION
During testing, `hatch tests` failed due to jax not being available in the hatch development environment. This addes jax as an extra dependency which allows the tests to pass.

This should not be considered a blocking issue/PR


openjournals/joss-reviews#7491
